### PR TITLE
refactor(security) : JWT 필터 와일드카드 패턴을 처리 로직 추가

### DIFF
--- a/src/main/java/com/homelearn/back/common/filter/JwtFilter.java
+++ b/src/main/java/com/homelearn/back/common/filter/JwtFilter.java
@@ -31,7 +31,8 @@ public class JwtFilter extends OncePerRequestFilter {
         log.info("Request path: " + requestPath);
 
         // 요청 경로가 PERMITTED_URL에 포함되는지 확인
-        boolean isPermittedPath = Arrays.asList(SecurityConfig.getPERMITTED_URL()).contains(requestPath);
+        boolean isPermittedPath = Arrays.stream(SecurityConfig.getPERMITTED_URL())
+                .anyMatch(permittedPath -> requestPath.startsWith(permittedPath.replace("/**", "")));
 
         if (isPermittedPath) {
             filterChain.doFilter(request, response);


### PR DESCRIPTION
PERMITTED_URL 배열에 /dong/** 패턴이 포함되어 있기 때문에, /dong/sido_list 경로로의 요청은 보안 인증을 거치지 않아야 합니다. 이 ** 패턴은 /dong/으로 시작하는 모든 경로와 일치합니다.

하지만, 중요한 점은 Spring Security의 antMatchers 메서드가 URL 패턴을 인식하지만, Java 코드 내의 Arrays.asList(...).contains(...) 메서드는 정확한 문자열 일치만을 확인합니다. 따라서, JwtFilter에서 사용하는 Arrays.asList(SecurityConfig.getPERMITTED_URL()).contains(requestPath) 로직은 /dong/**와 같은 와일드카드 패턴을 처리하지 못합니다.

이 문제를 해결하려면, JwtFilter에서 PERMITTED_URL을 확인할 때, URL 패턴 일치를 검사할 수 있는 로직으로 수정해야 합니다. 예를 들어, 아래와 같이 startsWith 메서드를 사용하여 일부 경로 일치를 확인할 수 있습니다

```java

Copy code
boolean isPermittedPath = Arrays.stream(SecurityConfig.getPERMITTED_URL())
                                .anyMatch(permittedPath -> requestPath.startsWith(permittedPath.replace("/**", "")));
```
이 코드는 PERMITTED_URL 배열의 각 항목에 대해 /**를 제거하고, 요청된 경로가 이들 중 하나로 시작하는지 확인합니다. 이렇게 하면 /dong/sido_list와 같은 경로에 대해서도 보안 인증을 거치지 않도록 설정할 수 있습니다.